### PR TITLE
feat: add movies grouped by genre endpoint 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@apollo/server": "4.3.0",
         "@as-integrations/aws-lambda": "1.2.1",
         "aws-sdk": "2.1306.0",
+        "contentful": "^10.6.9",
         "contentful-management": "10.26.0",
         "graphql": "16.6.0",
         "graphql-tag": "2.12.6",
@@ -2224,6 +2225,14 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@contentful/rich-text-types": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.3.0.tgz",
+      "integrity": "sha512-OfQmAu5bxE0CgQA3WlUleVej+ifFG/iXmB2DmUl4EyWyFue1aiIvfjxQhcDRSH4n1jUNMJ6L1wInZL8uV5m3TQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -7453,6 +7462,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/contentful": {
+      "version": "10.6.9",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.6.9.tgz",
+      "integrity": "sha512-OanVTe4i0l5N6WkSDEwx9Lt/XVoeevNDODn0XHEr56ShGs+a3/nJxaNUjNr4WmX9BklgARvsiOBsl/XTz5OVbQ==",
+      "dependencies": {
+        "@contentful/rich-text-types": "^16.0.2",
+        "axios": "^1.6.0",
+        "contentful-resolve-response": "^1.8.1",
+        "contentful-sdk-core": "^8.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "type-fest": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/contentful-management": {
       "version": "10.26.0",
       "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.26.0.tgz",
@@ -7467,6 +7492,22 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/contentful-resolve-response": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.8.1.tgz",
+      "integrity": "sha512-VXGK2c8dBIGcRCknqudKmkDr2PzsUYfjLN6hhx71T09UzoXOdA/c0kfDhsf/BBCBWPWcLaUgaJEFU0lCo45TSg==",
+      "dependencies": {
+        "fast-copy": "^2.1.7"
+      },
+      "engines": {
+        "node": ">=4.7.2"
+      }
+    },
+    "node_modules/contentful-resolve-response/node_modules/fast-copy": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
     },
     "node_modules/contentful-sdk-core": {
       "version": "7.1.0",
@@ -7487,6 +7528,46 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
       "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
+    },
+    "node_modules/contentful/node_modules/axios": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/contentful/node_modules/contentful-sdk-core": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.1.tgz",
+      "integrity": "sha512-0oWZmU4V9AgFVwljJLQc1sQJzxSodnLQk9TCmUTFw12rjiloPKYLRo4iz6KJD1enyVmZsz+Ckb0wADUVvFKg6A==",
+      "dependencies": {
+        "fast-copy": "^2.1.7",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "p-throttle": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/contentful/node_modules/fast-copy": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
+    },
+    "node_modules/contentful/node_modules/type-fest": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
+      "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -11406,6 +11487,11 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
     "node_modules/json-to-pretty-yaml": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
@@ -13101,6 +13187,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@apollo/server": "4.3.0",
     "@as-integrations/aws-lambda": "1.2.1",
     "aws-sdk": "2.1306.0",
+    "contentful": "^10.6.9",
     "contentful-management": "10.26.0",
     "graphql": "16.6.0",
     "graphql-tag": "2.12.6",

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,7 +18,7 @@ plugins:
 # The `provider` block defines where your service will be deployed
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 # The `functions` block defines what code to deploy
 functions:
@@ -40,4 +40,10 @@ functions:
     events:
       - http:
           path: healthcheck
+          method: get
+  moviesByGenre:
+    handler: src/handlers/moviesByGenre.handler
+    events:
+      - http:
+          path: genre/movies
           method: get

--- a/src/handlers/moviesByGenre.ts
+++ b/src/handlers/moviesByGenre.ts
@@ -1,6 +1,5 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import getAll from '../models/Genre/getAll';
-import { cdaClient, CONTENTFUL_LIMIT } from '../utils/contentful';
 
 export type HealthCheckResult = {
 	contentful: boolean;
@@ -15,15 +14,12 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 		}
 	}
 
-	const limit = CONTENTFUL_LIMIT;
-	const skip = (page - 1) * limit;
-
 	try {
-		const genres = await getAll({ limit, skip });
+		const result = await getAll({ page });
 
 		return {
 			statusCode: 200,
-			body: JSON.stringify(genres),
+			body: JSON.stringify(result),
 		};
 	} catch (err) {
 		console.error(err);

--- a/src/handlers/moviesByGenre.ts
+++ b/src/handlers/moviesByGenre.ts
@@ -1,0 +1,35 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import getAll from '../models/Genre/getAll';
+import { cdaClient, CONTENTFUL_LIMIT } from '../utils/contentful';
+
+export type HealthCheckResult = {
+	contentful: boolean;
+};
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+	let page = 1;
+	if (event.queryStringParameters && event.queryStringParameters.page) {
+		const parsedPage = parseInt(event.queryStringParameters.page, 10);
+		if (!isNaN(parsedPage) && parsedPage > 0) {
+			page = parsedPage;
+		}
+	}
+
+	const limit = CONTENTFUL_LIMIT;
+	const skip = (page - 1) * limit;
+
+	try {
+		const genres = await getAll({ limit, skip });
+
+		return {
+			statusCode: 200,
+			body: JSON.stringify(genres),
+		};
+	} catch (err) {
+		console.error(err);
+		return {
+			statusCode: 500,
+			body: JSON.stringify({ error: 'Internal Server Error' }),
+		};
+	}
+};

--- a/src/models/Genre/GenreModel.ts
+++ b/src/models/Genre/GenreModel.ts
@@ -1,0 +1,48 @@
+import { Entry, EntrySkeletonType, FieldsType } from 'contentful';
+
+type GenreContentfulEntry = Entry<EntrySkeletonType<FieldsType, string>, undefined, string>;
+
+export type Genre = {
+	id: string;
+	title: string | null;
+	movies: Array<GenreMovie>;
+};
+
+// Might want to add more fields here in the future
+export type GenreMovie = {
+	id: string;
+};
+
+export default class GenreModel {
+	public get id() {
+		return this.entry.sys.id;
+	}
+
+	public get title(): string | null {
+		return (this.entry.fields?.title as string) || '';
+	}
+	public set title(value: string | null) {
+		this.entry.fields.title = value;
+	}
+
+	public get movies(): Array<GenreMovie> {
+		return ((this.entry.fields?.movies as Array<GenreContentfulEntry>) || []).map((movie) => ({
+			id: movie.sys.id,
+		}));
+	}
+	public set movies(value: Array<GenreMovie>) {
+		this.entry.fields.movies = value.map((movie) => ({
+			sys: { id: movie.id },
+		}));
+	}
+
+	constructor(private entry: GenreContentfulEntry) {}
+
+	toGenre(): Genre {
+		return {
+			id: this.id,
+			title: this.title,
+			movies: this.movies,
+		};
+	}
+}

--- a/src/models/Genre/GenreModel.ts
+++ b/src/models/Genre/GenreModel.ts
@@ -1,6 +1,6 @@
 import { Entry, EntrySkeletonType, FieldsType } from 'contentful';
 
-type GenreContentfulEntry = Entry<EntrySkeletonType<FieldsType, string>, undefined, string>;
+export type GenreContentfulEntry = Entry<EntrySkeletonType<FieldsType, string>, undefined, string>;
 
 export type Genre = {
 	id: string;
@@ -37,12 +37,4 @@ export default class GenreModel {
 	}
 
 	constructor(private entry: GenreContentfulEntry) {}
-
-	toGenre(): Genre {
-		return {
-			id: this.id,
-			title: this.title,
-			movies: this.movies,
-		};
-	}
 }

--- a/src/models/Genre/getAll.ts
+++ b/src/models/Genre/getAll.ts
@@ -1,11 +1,11 @@
 import { DataWithPaginationResponse } from '../../types/apiResponse';
-import { cdaClient, ContentfulPaginationRequest, CONTENTFUL_LIMIT } from '../../utils/contentful';
+import { cdaClient, CONTENTFUL_LIMIT } from '../../utils/contentful';
 import { Genre } from './GenreModel';
 import parseGenre from './parseGenre';
 
-export default async function getAll({
-	page = 1,
-}: ContentfulPaginationRequest): Promise<DataWithPaginationResponse<Genre>> {
+export default async function getAll({ page = 1 }: { page?: number } = {}): Promise<
+	DataWithPaginationResponse<Genre>
+> {
 	const limit = CONTENTFUL_LIMIT;
 	const skip = (page - 1) * limit;
 

--- a/src/models/Genre/getAll.ts
+++ b/src/models/Genre/getAll.ts
@@ -1,0 +1,24 @@
+import { cdaClient, ContentfulPaginationRequest, CONTENTFUL_LIMIT } from '../../utils/contentful';
+import GenreModel from './GenreModel';
+
+export default async function getAll({
+	limit = CONTENTFUL_LIMIT,
+	skip = 0,
+}: ContentfulPaginationRequest) {
+	try {
+		const response = await cdaClient.getEntries({
+			content_type: 'genre',
+			select: ['sys.id', 'fields.title', 'fields.movies'],
+			skip,
+			limit,
+			order: ['fields.title'],
+			include: 0, // remove unecessary data - we don't care about includes here
+		});
+
+		return response.items.map((entry) => new GenreModel(entry).toGenre());
+	} catch (e) {
+		console.log('======= something went wrong fetch =======');
+		console.log(String(e));
+		throw e;
+	}
+}

--- a/src/models/Genre/getAll.ts
+++ b/src/models/Genre/getAll.ts
@@ -1,10 +1,14 @@
+import { DataWithPaginationResponse } from '../../types/apiResponse';
 import { cdaClient, ContentfulPaginationRequest, CONTENTFUL_LIMIT } from '../../utils/contentful';
-import GenreModel from './GenreModel';
+import { Genre } from './GenreModel';
+import parseGenre from './parseGenre';
 
 export default async function getAll({
-	limit = CONTENTFUL_LIMIT,
-	skip = 0,
-}: ContentfulPaginationRequest) {
+	page = 1,
+}: ContentfulPaginationRequest): Promise<DataWithPaginationResponse<Genre>> {
+	const limit = CONTENTFUL_LIMIT;
+	const skip = (page - 1) * limit;
+
 	try {
 		const response = await cdaClient.getEntries({
 			content_type: 'genre',
@@ -15,7 +19,8 @@ export default async function getAll({
 			include: 0, // remove unecessary data - we don't care about includes here
 		});
 
-		return response.items.map((entry) => new GenreModel(entry).toGenre());
+		const data = response.items.map((entry) => parseGenre(entry));
+		return { data, totalPages: Math.ceil(response.total / limit) };
 	} catch (e) {
 		console.log('======= something went wrong fetch =======');
 		console.log(String(e));

--- a/src/models/Genre/parseGenre.ts
+++ b/src/models/Genre/parseGenre.ts
@@ -1,0 +1,11 @@
+import { Genre, GenreContentfulEntry } from './GenreModel';
+
+export default function parseGenre(entry: GenreContentfulEntry): Genre {
+	return {
+		id: entry.sys.id,
+		title: entry.fields.title as string,
+		movies: ((entry.fields?.movies as Array<GenreContentfulEntry>) || []).map((movie) => ({
+			id: movie.sys.id,
+		})),
+	};
+}

--- a/src/models/Technology/create.ts
+++ b/src/models/Technology/create.ts
@@ -1,10 +1,10 @@
-import { getEnvironment } from '../../utils/contentful';
+import { getCMAEnvironment } from '../../utils/contentful';
 import TechnologyModel, { TechnologyFields } from './TechnologyModel';
 
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
 export default async function create(data: WithRequired<TechnologyFields, 'displayName'>) {
-	const environment = await getEnvironment();
+	const environment = await getCMAEnvironment();
 
 	const entry = await environment.createEntry('technology', {
 		fields: {

--- a/src/models/Technology/getAll.ts
+++ b/src/models/Technology/getAll.ts
@@ -1,9 +1,9 @@
-import { getEnvironment } from '../../utils/contentful';
+import { getCMAEnvironment } from '../../utils/contentful';
 import TechnologyModel from './TechnologyModel';
 
 export default async function getAll(limit?: number | null, skip?: number | null) {
 	try {
-		const environment = await getEnvironment();
+		const environment = await getCMAEnvironment();
 		const entries = await environment.getEntries({
 			content_type: 'technology',
 			limit: limit || 100,

--- a/src/models/Technology/getById.ts
+++ b/src/models/Technology/getById.ts
@@ -1,8 +1,8 @@
-import { getEnvironment } from '../../utils/contentful';
+import { getCMAEnvironment } from '../../utils/contentful';
 import TechnologyModel from './TechnologyModel';
 
 export default async function getById(id: string) {
-	const environment = await getEnvironment();
+	const environment = await getCMAEnvironment();
 	const entry = await environment.getEntry(id);
 
 	return new TechnologyModel(entry);

--- a/src/types/apiResponse.ts
+++ b/src/types/apiResponse.ts
@@ -1,0 +1,4 @@
+export type DataWithPaginationResponse<T> = {
+	data: Array<T>;
+	totalPages: number;
+};

--- a/src/utils/contentful/contentful-healthcheck.spec.ts
+++ b/src/utils/contentful/contentful-healthcheck.spec.ts
@@ -1,9 +1,9 @@
-import { getEnvironment } from './contentful';
+import { getCMAEnvironment } from './contentful';
 import { getContentfulHealth } from './contentful-healthcheck';
 
-const MOCK_GET_ENVIRONMENT = getEnvironment as jest.Mock;
+const MOCK_GET_ENVIRONMENT = getCMAEnvironment as jest.Mock;
 jest.mock('./contentful', () => ({
-	getEnvironment: jest.fn(),
+	getCMAEnvironment: jest.fn(),
 }));
 
 describe('.healthcheck', () => {

--- a/src/utils/contentful/contentful-healthcheck.ts
+++ b/src/utils/contentful/contentful-healthcheck.ts
@@ -1,8 +1,8 @@
-import { getEnvironment } from './contentful';
+import { getCMAEnvironment } from './contentful';
 
 export const getContentfulHealth = async () => {
 	try {
-		await getEnvironment();
+		await getCMAEnvironment();
 		return true;
 	} catch {
 		return false;

--- a/src/utils/contentful/contentful.spec.ts
+++ b/src/utils/contentful/contentful.spec.ts
@@ -1,5 +1,5 @@
 import { createClient, Environment } from 'contentful-management';
-import { getEnvironment } from './contentful';
+import { getCMAEnvironment } from './contentful';
 
 const dummyEnvironment = {
 	accessToken: 'DUMMYTOKEN',
@@ -21,7 +21,7 @@ describe('.getEnviroment', () => {
 	let environment: Environment;
 	let mockGetSpace: jest.Mock;
 	beforeAll(async () => {
-		environment = await getEnvironment();
+		environment = await getCMAEnvironment();
 	});
 
 	it('calls create client with expected arguments', () => {
@@ -37,11 +37,11 @@ describe('.getEnviroment', () => {
 		expect(mockGetSpace).toHaveBeenCalledWith('MOCK_CONTENTFUL_SPACE_ID');
 	});
 
-	it('calls getEnvironment function from space result with expected argument', async () => {
+	it('calls getCMAEnvironment function from space result with expected argument', async () => {
 		const mockGetSpaceResult = await mockGetSpace.mock.results[0].value;
-		const mockGetEnvironment = mockGetSpaceResult.getEnvironment;
-		expect(mockGetEnvironment).toHaveBeenCalledTimes(1);
-		expect(mockGetEnvironment).toHaveBeenCalledWith('MOCK_CONTENTFUL_ENVIRONMENT');
+		const mockgetCMAEnvironment = mockGetSpaceResult.getCMAEnvironment;
+		expect(mockgetCMAEnvironment).toHaveBeenCalledTimes(1);
+		expect(mockgetCMAEnvironment).toHaveBeenCalledWith('MOCK_CONTENTFUL_ENVIRONMENT');
 	});
 
 	it('returns expected result', () => {

--- a/src/utils/contentful/contentful.ts
+++ b/src/utils/contentful/contentful.ts
@@ -5,10 +5,6 @@ import * as dotenv from 'dotenv';
 // load dotenv config
 dotenv.config();
 
-export type ContentfulPaginationRequest = {
-	page?: number;
-};
-
 export const CONTENTFUL_LIMIT = 25;
 
 export const cdaClient = createCDAClient({

--- a/src/utils/contentful/contentful.ts
+++ b/src/utils/contentful/contentful.ts
@@ -6,8 +6,7 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 export type ContentfulPaginationRequest = {
-	limit?: number;
-	skip?: number;
+	page?: number;
 };
 
 export const CONTENTFUL_LIMIT = 25;

--- a/src/utils/contentful/contentful.ts
+++ b/src/utils/contentful/contentful.ts
@@ -1,15 +1,28 @@
 import { createClient, Environment } from 'contentful-management';
+import { createClient as createCDAClient } from 'contentful';
 import * as dotenv from 'dotenv';
 
 // load dotenv config
 dotenv.config();
 
-const client = createClient({
+export type ContentfulPaginationRequest = {
+	limit?: number;
+	skip?: number;
+};
+
+export const CONTENTFUL_LIMIT = 25;
+
+export const cdaClient = createCDAClient({
+	space: `${process.env.CONTENTFUL_SPACE_ID}`,
+	accessToken: `${process.env.CONTENTFUL_DELIVERY_API_TOKEN}`,
+});
+
+const cmaClient = createClient({
 	accessToken: `${process.env.CONTENTFUL_CONTENT_MANAGEMENT_API_TOKEN}`,
 });
 
-export async function getEnvironment(): Promise<Environment> {
-	const space = await client.getSpace(`${process.env.CONTENTFUL_SPACE_ID}`);
+export async function getCMAEnvironment(): Promise<Environment> {
+	const space = await cmaClient.getSpace(`${process.env.CONTENTFUL_SPACE_ID}`);
 	const environment = await space.getEnvironment(`${process.env.CONTENTFUL_ENVIRONMENT}`);
 
 	return environment;

--- a/src/utils/contentful/index.ts
+++ b/src/utils/contentful/index.ts
@@ -1,2 +1,2 @@
-export { getEnvironment } from './contentful';
+export * from './contentful';
 export { getContentfulHealth } from './contentful-healthcheck';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
 	"compilerOptions": {
-		"module": "esnext",
+		"module": "CommonJS",
 		"moduleResolution": "node",
 		"outDir": "dist",
 		"lib": ["esnext"],
 		"preserveConstEnums": true,
 		"strict": true,
-		"target": "es2017",
+		"target": "ES2020",
 		"sourceMap": true,
 		"esModuleInterop": true,
 		"resolveJsonModule": true,


### PR DESCRIPTION
This adds a new endpoint for `GET /genres/movies`.

The API response follows the pattern below:
```
{
  "data": [
    {
      "id": "<someID>",
      "title": "Action",
      "movies": [{"id": "<someMovieID>"}, {"id": "<someMovieID>"}]
    }
  ],
  "totalPages": 1
}
```
