### PR TITLE
chore: refactor genre movies endpoint

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -47,3 +47,6 @@ functions:
       - http:
           path: genre/movies
           method: get
+    environment:
+      CONTENTFUL_SPACE_ID: ${env:CONTENTFUL_SPACE_ID}
+      CONTENTFUL_DELIVERY_API_TOKEN: ${env:CONTENTFUL_DELIVERY_API_TOKEN}

--- a/src/handlers/moviesByGenre.ts
+++ b/src/handlers/moviesByGenre.ts
@@ -22,7 +22,6 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 			body: JSON.stringify(result),
 		};
 	} catch (err) {
-		console.error(err);
 		return {
 			statusCode: 500,
 			body: JSON.stringify({ error: 'Internal Server Error' }),

--- a/src/models/Genre/getAll.ts
+++ b/src/models/Genre/getAll.ts
@@ -1,12 +1,13 @@
 import { DataWithPaginationResponse } from '../../types/apiResponse';
-import { cdaClient, CONTENTFUL_LIMIT } from '../../utils/contentful';
+import { PaginationOptions } from '../../types/pagination';
+import { cdaClient, DEFAULT_CONTENTFUL_LIMIT } from '../../utils/contentful';
 import { Genre } from './GenreModel';
 import parseGenre from './parseGenre';
 
-export default async function getAll({ page = 1 }: { page?: number } = {}): Promise<
-	DataWithPaginationResponse<Genre>
-> {
-	const limit = CONTENTFUL_LIMIT;
+export default async function getAll({
+	page = 1,
+	limit = DEFAULT_CONTENTFUL_LIMIT,
+}: PaginationOptions = {}): Promise<DataWithPaginationResponse<Genre>> {
 	const skip = (page - 1) * limit;
 
 	try {
@@ -21,9 +22,8 @@ export default async function getAll({ page = 1 }: { page?: number } = {}): Prom
 
 		const data = response.items.map((entry) => parseGenre(entry));
 		return { data, totalPages: Math.ceil(response.total / limit) };
-	} catch (e) {
-		console.log('======= something went wrong fetch =======');
-		console.log(String(e));
-		throw e;
+	} catch (err) {
+		console.error(err);
+		throw err;
 	}
 }

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,0 +1,4 @@
+export type PaginationOptions = {
+	page?: number;
+	limit?: number;
+};

--- a/src/utils/contentful/contentful.ts
+++ b/src/utils/contentful/contentful.ts
@@ -5,13 +5,23 @@ import * as dotenv from 'dotenv';
 // load dotenv config
 dotenv.config();
 
-export const CONTENTFUL_LIMIT = 25;
+export const DEFAULT_CONTENTFUL_LIMIT = 25;
 
+// Content Delivery API - https://www.contentful.com/developers/docs/references/content-delivery-api/
+// Use this to read data from Contentful
 export const cdaClient = createCDAClient({
 	space: `${process.env.CONTENTFUL_SPACE_ID}`,
 	accessToken: `${process.env.CONTENTFUL_DELIVERY_API_TOKEN}`,
 });
 
+// Content Management API - https://www.contentful.com/developers/docs/references/content-management-api/
+// Use this to manage content in your spaces
+//
+// From website:
+// Note: You can use the CMA to deliver and manage content, but you shouldn't use it to deliver large
+// amounts of content and instead use the Content Delivery API. The structure of responses from the
+// CMA differs from the CDA as GET responses retrieve the entirety of items (i.e. all localized and
+// unpublished content).
 const cmaClient = createClient({
 	accessToken: `${process.env.CONTENTFUL_CONTENT_MANAGEMENT_API_TOKEN}`,
 });


### PR DESCRIPTION
Applying some refactoring to previous merge:
- Adding env var to yml file so AWS reads them
- Better error handling
- Making `limit` a configurable option
- More clarity on CMA vs CDA