### PR TITLE
feat: add simple auth with fetch valid token

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -25,6 +25,26 @@ provider:
 
 # The `functions` block defines what code to deploy
 functions:
+  # auth functions & APIs
+  simpleAuthorizerFunc:
+    handler: src/handlers/auth/authorizer.handler
+  getValidToken:
+    handler: src/handlers/auth/getValidToken.handler
+    events:
+      - http:
+          path: auth/token
+          method: get
+          cors: true
+
+  # healthcheck - check status of the app
+  healthcheck:
+    handler: src/handlers/healthcheck.handler
+    events:
+      - http:
+          path: healthcheck
+          method: get
+
+  # graphql
   graphql:
     handler: src/handlers/graphql.server
     events:
@@ -38,25 +58,26 @@ functions:
           cors: true
     environment:
       SLS_STAGE: ${sls:stage}
-  healthcheck:
-    handler: src/handlers/healthcheck.handler
-    events:
-      - http:
-          path: healthcheck
-          method: get
+
+  # RESTful APIs
   moviesByGenre:
     handler: src/handlers/genres/moviesByGenre.handler
     events:
       - http:
           path: genres/movies
           method: get
+          cors: true
+          authorizer:
+            name: simpleAuthorizerFunc
   movies:
     handler: src/handlers/movies/getMovies.handler
     events:
       - http:
-          path: /movies
+          path: movies
           method: get
           cors: true
+          authorizer:
+            name: simpleAuthorizerFunc
   movieById:
     handler: src/handlers/movies/movieById.handler
     events:
@@ -64,6 +85,8 @@ functions:
           path: movies/{id}
           method: get
           cors: true
+          authorizer:
+            name: simpleAuthorizerFunc
   movieTitles:
     handler: src/handlers/movies/getMovieTitles.handler
     events:
@@ -71,6 +94,8 @@ functions:
           path: movies/titles
           method: get
           cors: true
+          authorizer:
+            name: simpleAuthorizerFunc
   genreById:
     handler: src/handlers/genres/genreById.handler
     events:
@@ -78,3 +103,5 @@ functions:
           path: movies/genres/{id}
           method: get
           cors: true
+          authorizer:
+            name: simpleAuthorizerFunc

--- a/src/handlers/auth/authorizer.ts
+++ b/src/handlers/auth/authorizer.ts
@@ -8,6 +8,7 @@ export const handler: APIGatewayRequestAuthorizerHandler = async (event) => {
 	const token = authorization.substring(7);
 	const isAuthorized = isTokenValid(token);
 
+	// ref: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html#http-api-lambda-authorizer.payload-format-response
 	return {
 		principalId: 'simpleAuthorizerPrincipal', // principal user identification associated with the token sent by the client - let's hardcode for simplicity
 		policyDocument: {

--- a/src/handlers/auth/authorizer.ts
+++ b/src/handlers/auth/authorizer.ts
@@ -1,0 +1,24 @@
+import { APIGatewayRequestAuthorizerHandler } from 'aws-lambda';
+import { isTokenValid } from '../../utils/api/apiAuth';
+
+export const handler: APIGatewayRequestAuthorizerHandler = async (event) => {
+	const authorization = event.headers?.['Authorization'] || '';
+
+	// removing the initial "Bearer "
+	const token = authorization.substring(7);
+	const isAuthorized = isTokenValid(token);
+
+	return {
+		principalId: 'simpleAuthorizerPrincipal', // principal user identification associated with the token sent by the client - let's hardcode for simplicity
+		policyDocument: {
+			Version: '2012-10-17',
+			Statement: [
+				{
+					Effect: isAuthorized ? 'Allow' : 'Deny',
+					Action: ['execute-api:Invoke'],
+					Resource: ['*'], // all resources in this project - for this purpose this is fine
+				},
+			],
+		},
+	};
+};

--- a/src/handlers/auth/getValidToken.ts
+++ b/src/handlers/auth/getValidToken.ts
@@ -1,0 +1,10 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { getRandomValidToken } from '../../utils/api/apiAuth';
+
+export const handler: APIGatewayProxyHandler = async () => {
+	const validToken = getRandomValidToken();
+	return {
+		statusCode: 200,
+		body: JSON.stringify({ token: validToken }),
+	};
+};

--- a/src/handlers/graphql.ts
+++ b/src/handlers/graphql.ts
@@ -39,6 +39,7 @@ export const apolloServer = new ApolloServer<MyContext>({
 
 export const server = startServerAndCreateLambdaHandler<MyContext>(apolloServer, {
 	context: async ({ event }) => {
+		// ref: https://www.apollographql.com/docs/apollo-server/security/authentication/#api-wide-authorization
 		const authorization = event.headers?.['Authorization'] || '';
 
 		if (!authorization) {

--- a/src/utils/api/apiAuth.ts
+++ b/src/utils/api/apiAuth.ts
@@ -1,0 +1,20 @@
+// Genereated from https://jwt.io/
+export const authorizedJWTs = [
+	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJvcGVuSnd0MCIsIm5hbWUiOiJPcGVuSldUWzBdIn0.49JQF4ICJeqxpiIZ9x748VVOHj6FElyRm1tNpFGqaUY',
+	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJvcGVuSnd0MSIsIm5hbWUiOiJPcGVuSldUWzFdIn0.n8x8GHYe8RQYKkAoMVMlw9-FMZ57bs0HrwxBeJn3hQM',
+	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJvcGVuSnd0MiIsIm5hbWUiOiJPcGVuSldUWzJdIn0.ZV0H5kJrzOsfk3guI9pHt1bp0xzuCEFiuS4bP1XbEZE',
+	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJvcGVuSnd0MyIsIm5hbWUiOiJPcGVuSldUWzNdIn0.J43mgsvQlOK0zn7APkizIRkKphNIeXwtcabyKxoUnZo',
+	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJvcGVuSnd0NCIsIm5hbWUiOiJPcGVuSldUWzRdIn0.FEyU1vuRnD1wDw2kxuks59N9paTibhKHT8U9cpFw1dM',
+];
+
+export function isTokenValid(token: string) {
+	if (!token) {
+		return false;
+	}
+	return authorizedJWTs.includes(token);
+}
+
+export function getRandomValidToken(): string {
+	const randomIdx = Math.floor(Math.random() * authorizedJWTs.length);
+	return authorizedJWTs[randomIdx];
+}


### PR DESCRIPTION
Resolves #14

This adds a new endpoint for retrieving a valid token (Bearer type).

Retrieving a valid token:
![Screenshot 2023-11-21 at 2 17 59 PM](https://github.com/thisdot/movies-api/assets/22064697/665f3aa4-e714-4e38-8f48-f65c61ae25ad)

Calling REST API with valid token retrieved:
![Screenshot 2023-11-21 at 2 19 50 PM](https://github.com/thisdot/movies-api/assets/22064697/9391e4e9-e19a-4096-8fb1-61ff73ab0403)

Calling REST API with invalid token:
![Screenshot 2023-11-21 at 2 20 17 PM](https://github.com/thisdot/movies-api/assets/22064697/a6831743-f9f7-48a5-a81b-8c46b2b4b599)

GraphQL side - config:
![Screenshot 2023-11-21 at 2 54 55 PM](https://github.com/thisdot/movies-api/assets/22064697/d7d570d2-5810-4a1c-aa1f-8edd7a0ca0ac)

And query working:
![Screenshot 2023-11-21 at 2 55 20 PM](https://github.com/thisdot/movies-api/assets/22064697/e599077e-d210-4bde-a191-12d1b416d84d)
