### PR TITLE
fix: serverless offline tsc paths build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "serverless-dotenv-plugin": "4.0.2",
         "serverless-offline": "12.0.4",
         "serverless-plugin-typescript": "^2.1.5",
+        "serverless-tscpaths": "^0.0.8",
         "ts-jest": "29.0.5",
         "ts-node": "10.9.1",
         "typescript": "4.9.4"
@@ -2219,6 +2220,88 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@baemingo/tscpaths-async": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@baemingo/tscpaths-async/-/tscpaths-async-0.0.15.tgz",
+      "integrity": "sha512-FavCb0PaEROev0paWptEvMnVDpzjet2MuxgN0E6mjU0tUwCVYAhhwBdmAdKj0DyAWbSxFP5lkIPLOT0EddQsDQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^4.0.1",
+        "fs-extra": "^8.1.0",
+        "globby": "^10.0.0",
+        "typescript": "^3.4.5"
+      },
+      "bin": {
+        "tscpaths": "cjs/index.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@baemingo/tscpaths-async/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@baemingo/tscpaths-async/node_modules/globby": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@baemingo/tscpaths-async/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@baemingo/tscpaths-async/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@baemingo/tscpaths-async/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -14172,6 +14255,19 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/serverless-tscpaths": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/serverless-tscpaths/-/serverless-tscpaths-0.0.8.tgz",
+      "integrity": "sha512-ea9AHJSMfliwUV20f/oHPZNVd/jX5d5b+kVilIa8uFJu0J/CKDvnOqSoVwq6W5vqOmP8jgtuSGQQ9T7RbRr4Iw==",
+      "dev": true,
+      "dependencies": {
+        "@baemingo/tscpaths-async": "^0.0.15",
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/serverless/node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "serverless-dotenv-plugin": "4.0.2",
     "serverless-offline": "12.0.4",
     "serverless-plugin-typescript": "^2.1.5",
+    "serverless-tscpaths": "^0.0.8",
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "typescript": "4.9.4"

--- a/serverless.yml
+++ b/serverless.yml
@@ -11,8 +11,10 @@ frameworkVersion: '3'
 useDotenv: true
 
 plugins:
-  - serverless-offline
+  # https://www.serverless.com/plugins/serverless-plugin-typescript - typescript must precede offline
   - serverless-plugin-typescript
+  - serverless-tscpaths
+  - serverless-offline
   - serverless-dotenv-plugin
 
 # The `provider` block defines where your service will be deployed


### PR DESCRIPTION
`sls offline`, from `npm run dev` are not processing typescript paths, so it's causing the error:
![Screenshot 2023-11-24 at 1 29 14 PM](https://github.com/thisdot/movies-api/assets/22064697/94434092-2530-4f3e-b833-9ec98ec50cc3)

This installs the plugin `serverless-tscpaths` to remap our paths.